### PR TITLE
Adding an environment variable to enable shortcuts in cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,27 @@ Alternatively, you can build and start it all at once without installing: (conve
 python -m thriftcli server_address endpoint_name thrift_file_path [options]
 ```
 
-As a convenience you can define an environment variable THRIFT_CLI_PATH. A : delimited list of paths to search
-for thrift files. This makes the commands you write simpler
+As a convenience you can define an environment variable THRIFT_CLI_PATH. This colon delimited list of directories will be used to find thrift files and their dependencies.
+
+Take the following command 
+
+```
+thriftcli localhost:9332 MakeTestCall ~/thrift/test/test.thrift -I ~/thrift/dependencies
+```
+
+If you had run the following before
+
+```
+export THRIFT_CLI_PATH="~/thrift/test:~/thrift/dependencies"
+```
+
+this command becomes
+
+```
+thriftcli localhost:9332 MakeTestCall test.thrift
+```
+
+This variable is most useful for endpoints you call fairly often
 
 Arguments:
 - **server_address**       URL to send the request to. This server should listen for and implement the requested endpoint.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Alternatively, you can build and start it all at once without installing: (conve
 python -m thriftcli server_address endpoint_name thrift_file_path [options]
 ```
 
+As a convenience you can define an environment variable THRIFT_CLI_PATH. A : delimited list of paths to search
+for thrift files. This makes the commands you write simpler
+
 Arguments:
 - **server_address**       URL to send the request to. This server should listen for and implement the requested endpoint.
 - **endpoint_name**        Service name and function name representing the request to send to the server.

--- a/thriftcli/thrift_cli.py
+++ b/thriftcli/thrift_cli.py
@@ -21,6 +21,7 @@ from .thrift_executor import ThriftExecutor
 from .thrift_parser import ThriftParser
 from .request_body_converter import convert
 
+THRIFT_PATH_ENVIRONMENT_VARIABLE = 'THRIFT_CLI_PATH'
 
 class ThriftCLI(object):
     """ Provides an interface for setting up a client, making requests, and cleaning up.
@@ -43,12 +44,12 @@ class ThriftCLI(object):
         :type zookeeper: bool
 
         """
-        self._thrift_path = thrift_path
-        self._thrift_argument_converter = ThriftArgumentConverter(thrift_path, thrift_dir_paths)
+        self._thrift_path = _find_path(thrift_path)
+        self._thrift_argument_converter = ThriftArgumentConverter(self._thrift_path, thrift_dir_paths)
         self._service_reference = '%s.%s' % (ThriftParser.get_package_name(self._thrift_path), service_name)
         if zookeeper:
             server_address = get_server_address(server_address, service_name)
-        self._thrift_executor = ThriftExecutor(thrift_path, server_address, self._service_reference, 
+        self._thrift_executor = ThriftExecutor(self._thrift_path, server_address, self._service_reference,
             self._thrift_argument_converter._parse_result.namespaces, thrift_dir_paths)
 
     def run(self, method_name, request_body, return_json=False):
@@ -72,6 +73,22 @@ class ThriftCLI(object):
     def cleanup(self, remove_generated_src=False):
         """ Deletes the gen-py code and closes the transport with the server. """
         self._thrift_executor.cleanup(remove_generated_src)
+
+
+def _find_path(path):
+    if os.path.isfile(path):
+        return path
+    else:
+        thrift_file = os.path.basename(path)
+        for thrift_path in os.environ.get(THRIFT_PATH_ENVIRONMENT_VARIABLE, '').split(':'):
+            try:
+                if thrift_file in os.listdir(thrift_path):
+                    return os.path.join(thrift_path, thrift_file)
+            except OSError:
+                # Dir did not contain file needed
+                continue
+
+    raise IOError("Unable to find {}".format(path))
 
 
 def _split_endpoint(endpoint):
@@ -191,7 +208,16 @@ def _run_cli(server_address, endpoint_name, thrift_path, thrift_dir_paths, reque
 
     """
     [service_name, method_name] = _split_endpoint(endpoint_name)
-    cli = ThriftCLI(thrift_path, server_address, service_name, thrift_dir_paths, zookeeper)
+    environment_defined_paths = []
+    if os.environ.get(THRIFT_PATH_ENVIRONMENT_VARIABLE):
+        environment_defined_paths = os.environ[THRIFT_PATH_ENVIRONMENT_VARIABLE].split(':')
+    cli = ThriftCLI(
+        thrift_path,
+        server_address,
+        service_name,
+        thrift_dir_paths + environment_defined_paths,
+        zookeeper
+    )
     try:
         result = cli.run(method_name, request_body, return_json)
         if result is not None:


### PR DESCRIPTION
If yall like this change we can talk about steps to polish it for merging (tests, docs)

* Adds environment variable THRIFT_CLI_PATH that allows you to specify paths for dependencies and thrift files that the code will search for.

That turns this command
```thriftcli localhost:30001 TrackerEventLogService.getEventHistoryForDeviceById /Users/mbachmann/code/weightsite/tracker-event-log/thrifts/server/src/main/thrift/TrackerEventLogService.thrift -I ~/code/weightsite/core/thrift/rpc/thrifts/src/main/thrift/ -b body.json```

into 
```thriftcli localhost:30001 TrackerEventLogService.getEventHistoryForDeviceById TrackerEventLogService.thrift -b ~/Desktop/body.json```

by exporting the following

```export THRIFT_CLI_PATH='~/code/weightsite/core/thrift/rpc/thrifts/src/main/thrift/:/Users/mbachmann/code/weightsite/tracker-event-log/thrifts/server/src/main/thrift/'```