### PR TITLE
Pretty print when providing the json response

### DIFF
--- a/thriftcli/thrift_cli.py
+++ b/thriftcli/thrift_cli.py
@@ -66,7 +66,7 @@ class ThriftCLI(object):
         request_args = self._thrift_argument_converter.convert_args(self._service_reference, method_name, request_body)
         result = self._thrift_executor.run(method_name, request_args)
         if return_json:
-            result = json.dumps(result, default=lambda o: o.__dict__)
+            result = json.dumps(result, default=lambda o: o.__dict__, sort_keys=True, indent=4, separators=(',', ': '))
         return result
 
     def cleanup(self, remove_generated_src=False):


### PR DESCRIPTION
Is there any reason json is not just the default? Is there a case where they want the raw thrift repr?

Btw here is what the result looks like

```
{
    "error": {
        "errors": [
            {
                "location": "deviceId",
                "message": "Resource not found with key '103886041'",
                "reason": 7
            }
        ]
    },
    "trackerEventLogs": null
}
```