### PR TITLE
Pretty print example request when no request provided

### DIFF
--- a/thriftcli/thrift_cli.py
+++ b/thriftcli/thrift_cli.py
@@ -65,6 +65,16 @@ class ThriftCLI(object):
         """
         request_args = self._thrift_argument_converter.convert_args(self._service_reference, method_name, request_body)
         result = self._thrift_executor.run(method_name, request_args)
+        if not request_body:
+            raise ValueError(
+                "No Request Body provided. {} a request should look roughly like this:\n{}".format(
+                    method_name,
+                    json.dumps(
+                        request_args,
+                        default=lambda o: o.__dict__, sort_keys=True, indent=4, separators=(',', ': ')
+                    )
+                )
+            )
         if return_json:
             result = json.dumps(result, default=lambda o: o.__dict__)
         return result


### PR DESCRIPTION
```
/Users/mbachmann/Desktop/thriftcli/venv/bin/python2.7 /Users/mbachmann/Desktop/thriftcli/thriftcli-runner.py localhost:30001 TrackerEventLogService.getEventHistoryForDeviceById TrackerEventLogService.thrift
Traceback (most recent call last):
  File "/Users/mbachmann/Desktop/thriftcli/thriftcli-runner.py", line 18, in <module>
    main()
  File "/Users/mbachmann/Desktop/thriftcli/thriftcli/thrift_cli.py", line 254, in main
    _run_cli(*args)
  File "/Users/mbachmann/Desktop/thriftcli/thriftcli/thrift_cli.py", line 232, in _run_cli
    result = cli.run(method_name, request_body, return_json)
  File "/Users/mbachmann/Desktop/thriftcli/thriftcli/thrift_cli.py", line 75, in run
    default=lambda o: o.__dict__, sort_keys=True, indent=4, separators=(',', ': ')
ValueError: No Request Body provided. getEventHistoryForDeviceById a request should look roughly like this:
{
    "request": {
        "deviceId": null,
        "eventHistoryFilterParams": null
    }
}
```