### PR TITLE
Provide verbose logging mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
 - **-z --zookeeper**       Treat the server address as a Zookeeper instance, and make the request to the service being provided at the given path.
 - **-c --cleanup**         Delete generated code from filesystem after execution
 - **-j --json**            Print result in JSON format
+- **-v --verbose**         Provide detailed logging
 
 ## Examples
 


### PR DESCRIPTION
I wanna do some testing next time i'm in the office but here is my updated idea @mgedigian-fitbit for logging the request. I provide an argument `-v` that if provided I dump the request before it is sent. This can provide the user a more detailed view of what is expected and how the provided input is being interpreted.

By default. Nothing is logged (I dont use log level info). We can add more to this "verbose" logging but I just wanted to show the basic thinking.