### PR TITLE
Add a build

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+    *venv*
+    *tests*
+    *gen-py*

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@ omit =
     *venv*
     *tests*
     *gen-py*
+    *virtualenv*

--- a/.idea/thriftCompiler.xml
+++ b/.idea/thriftCompiler.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ThriftCompiler">
-    <compilers />
-  </component>
-</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+install:
+  - pip install .
+script:
+  - python -m unittest discover tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ install:
   - pip install .
 script:
   - coverage run -m unittest discover tests
-  - coverage report
+  - coverage report --fail-under 86

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: python
 install:
   - pip install .
 script:
-  - python -m unittest discover tests
+  - coverage run -m unittest discover tests
+  - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 install:
   - pip install .
+  - pip install coveralls
 script:
   - coverage run -m unittest discover tests
-  - coverage report --fail-under 86
+  - coverage report
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/Bachmann1234/thriftcli.svg?branch=master)](https://travis-ci.org/Bachmann1234/thriftcli)
-[![Coverage Status](https://coveralls.io/repos/github/Bachmann1234/thriftcli/badge.svg?branch=travis_ci)](https://coveralls.io/github/Bachmann1234/thriftcli?branch=master)
+[![Build Status](https://travis-ci.org/Fitbit/thriftcli.svg?branch=master)](https://travis-ci.org/Fitbit/thriftcli)
+[![Coverage Status](https://coveralls.io/repos/github/Fitbit/thriftcli/badge.svg?branch=master)](https://coveralls.io/github/Fitbit/thriftcli?branch=master)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build Status](https://travis-ci.org/Bachmann1234/thriftcli.svg?branch=travis_ci "Build Status")
+
 ## About
 
 ThriftCLI is a CLI tool for executing RPC's via the Thrift protocol.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Build Status](https://travis-ci.org/Bachmann1234/thriftcli.svg?branch=travis_ci "Build Status")
+[![Build Status](https://travis-ci.org/Bachmann1234/thriftcli.svg?branch=master)](https://travis-ci.org/Bachmann1234/thriftcli)
+[![Coverage Status](https://coveralls.io/repos/github/Bachmann1234/thriftcli/badge.svg?branch=travis_ci)](https://coveralls.io/github/Bachmann1234/thriftcli?branch=master)
 
 ## About
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ config = {
     'entry_points': {
         'console_scripts': ['thriftcli = thriftcli.thrift_cli:main']
     },
-    'install_requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc'],
-    'requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc'],
+    'install_requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc', 'coverage'],
+    'requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc', 'coverage'],
     'use_scm_version': {'version_scheme': make_version_unique},
     'setup_requires': ['setuptools_scm']
 }

--- a/tests/test_request_body_converter.py
+++ b/tests/test_request_body_converter.py
@@ -9,11 +9,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from __future__ import absolute_import
 import unittest
-import data
-
-from thriftcli.request_body_converter import convert
+from tests import data
+from thriftcli import convert
 
 
 class TestRequestBodyConverter(unittest.TestCase):

--- a/tests/test_thrift_argument_converter.py
+++ b/tests/test_thrift_argument_converter.py
@@ -14,7 +14,7 @@ import unittest
 
 import mock
 
-import data
+from tests import data
 from thriftcli import ThriftArgumentConverter, ThriftCLIError
 
 

--- a/tests/test_thrift_cli.py
+++ b/tests/test_thrift_cli.py
@@ -16,8 +16,8 @@ import unittest
 
 import mock
 
-import data
-from data.generated.Sample.ttypes import SampleResponse
+from tests import data
+from tests.data.generated.Sample.ttypes import SampleResponse
 from thriftcli import thrift_cli, ThriftCLIError
 
 

--- a/tests/test_thrift_executor.py
+++ b/tests/test_thrift_executor.py
@@ -14,7 +14,7 @@ import unittest
 
 import mock
 
-import data
+from tests import data
 from thriftcli import ThriftExecutor
 
 

--- a/tests/test_thrift_parser.py
+++ b/tests/test_thrift_parser.py
@@ -14,7 +14,7 @@ import unittest
 
 import mock
 
-import data
+from tests import data
 from thriftcli import ThriftParser, ThriftParseResult, ThriftCLIError
 
 

--- a/tests/test_thrift_zookeeper_resolver.py
+++ b/tests/test_thrift_zookeeper_resolver.py
@@ -14,7 +14,7 @@ import unittest
 
 import mock
 
-import data
+from tests import data
 from thriftcli import ThriftCLIError
 from thriftcli.thrift_zookeeper_resolver import get_server_address, _get_znode_from_zookeeper_host
 

--- a/thriftcli/request_body_converter.py
+++ b/thriftcli/request_body_converter.py
@@ -10,11 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json_request_body_converter
-import java_thrift_request_body_converter
 
 # These converters will be attempted in order. The first to successfully convert the request body will be used.
 # Each converter must implement the convert method.
+from thriftcli import java_thrift_request_body_converter
+from thriftcli import json_request_body_converter
+
 CONVERTERS = [
     json_request_body_converter,
     java_thrift_request_body_converter


### PR DESCRIPTION
This adds CI to this project

1. Fix some warnings caused by relative imports
2. Add Travis CI. It installs the project and runs the tests. Warns if a PR has failing tests
     Example build on my fork https://travis-ci.org/Bachmann1234/thriftcli/builds/305276257
3. Add Coveralls. This provides detailed coverage reports. Warns if PR causes coverage to drop
     Example report on my fork https://coveralls.io/github/Bachmann1234/thriftcli

If you want this you will need to do some tweaks post merge.

1. Turn on coveralls and travis for the main repo. Requires an account but is free for open source projects.

2. Change embedded badges to point to your repo not my fork


If we want to I can setup travis to automatically push changes to master to pypi. Enabling full continuous deployment.