### PR TITLE
Support uploading to pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ config = {
         'console_scripts': ['thriftcli = thriftcli.thrift_cli:main']
     },
     'install_requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc', 'coverage'],
-    'requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc', 'coverage'],
-    'setup_requires': ['setuptools_scm']
 }
 
 setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,10 @@
 from setuptools import setup
 
 
-def make_version_unique(version):
-    if version.exact:
-        return version.format_with('{tag}+{time:%s}')
-    else:
-        return version.format_with('{tag}.post{distance}+{time:%s}')
-
 
 config = {
     'name': 'thriftcli',
+    'version': 1.0,
     'description': 'Thrift CLI',
     'author': 'Neel Virdy',
     'packages': ['thriftcli'],
@@ -30,7 +25,6 @@ config = {
     },
     'install_requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc', 'coverage'],
     'requires': ['kazoo', 'mock', 'thrift', 'twitter.common.rpc', 'coverage'],
-    'use_scm_version': {'version_scheme': make_version_unique},
     'setup_requires': ['setuptools_scm']
 }
 


### PR DESCRIPTION
Looking into this I had to make some changes to support pypi. The biggest concern for maintenance is that the version number will now need to be incremented manually. 

Here is the package I uploaded https://pypi.python.org/pypi?:action=display&name=thriftcli&version=1.0 
