### PR TITLE
Support relative includes

### DIFF
--- a/thriftcli/thrift_parser.py
+++ b/thriftcli/thrift_parser.py
@@ -42,7 +42,7 @@ class ThriftParser(object):
     # For example:
     #   includes "File.thrift"
     #   => ("File.thrift")
-    INCLUDES_REGEX = re.compile(r'^include\s+\"(\w+.thrift)\"', flags=re.MULTILINE)
+    INCLUDES_REGEX = re.compile(r'^include\s+\"([\w./]+.thrift)\"', flags=re.MULTILINE)
 
     # Matches Thrift python namespace statements. Captures the namespace.
     #


### PR DESCRIPTION
An `include "../base/base.thrift"` is not matched by the current regex. This fixes that.