### PR TITLE
Fixes version in use of twitter.common.rpc to 0.3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ config = {
     'entry_points': {
         'console_scripts': ['thriftcli = thriftcli.thrift_cli:main']
     },
-    'install_requires': ['kazoo', 'mock', 'requests_kerberos', 'thrift', 'twitter.common.rpc', 'coverage'],
+    'install_requires': ['kazoo', 'mock', 'requests_kerberos', 'thrift', 'twitter.common.rpc==0.3.9', 'coverage'],
 }
 
 setup(**config)


### PR DESCRIPTION
`twitter.common.rpc` was updated version 0.3.11 doesn't feature `TFinagleProtocol`

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 163, in _run_module_as_main
    mod_name, _Error)
  File "/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 111, in _get_module_details
    __import__(mod_name)  # Do not catch exceptions initializing package
  File "thriftcli/__init__.py", line 14, in <module>
    from .thrift_cli import *
  File "thriftcli/thrift_cli.py", line 21, in <module>
    from .thrift_executor import ThriftExecutor
  File "thriftcli/thrift_executor.py", line 22, in <module>
    from twitter.common.rpc.finagle.protocol import TFinagleProtocol
ImportError: No module named finagle.protocol
```