### PR TITLE
Making it work with python 3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ If you would like to contribute to the ThriftCLI project, please use this workfl
 
 #### Running from Source
 
+Please note that thriftcli is Python 3 ONLY.
+
 If you'd like to run ThriftCLI from its source, without running the install script, navigate to the project directory and run:
 
 ```

--- a/thriftcli/thrift_cli.py
+++ b/thriftcli/thrift_cli.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 
-from thrift_zookeeper_resolver import get_server_address
+from .thrift_zookeeper_resolver import get_server_address
 from .thrift_argument_converter import ThriftArgumentConverter
 from .thrift_cli_error import ThriftCLIError
 from .thrift_executor import ThriftExecutor
@@ -158,7 +158,7 @@ def _load_request_body(request_body_arg):
         request_body_arg = _load_file(request_body_arg)
     try:
         return convert(request_body_arg)
-    except ValueError, e:
+    except ValueError as e:
         raise ThriftCLIError(e)
 
 
@@ -260,7 +260,7 @@ def _run_cli(server_address, endpoint_name, thrift_path, thrift_dir_paths, reque
     try:
         result = cli.run(method_name, request_body, return_json)
         if result is not None:
-            print result
+            print(result)
     finally:
         cli.cleanup(remove_generated_src)
 

--- a/thriftcli/thrift_executor.py
+++ b/thriftcli/thrift_executor.py
@@ -150,7 +150,7 @@ class ThriftExecutor(object):
         """
         if '//' not in address:
             address = '//' + address
-        url_obj = urlparse.urlparse(address)
+        url_obj = urllib.parse.urlparse(address)
         return url_obj.hostname, url_obj.port
 
     @staticmethod

--- a/thriftcli/thrift_executor.py
+++ b/thriftcli/thrift_executor.py
@@ -15,7 +15,7 @@ import os
 import shutil
 import subprocess
 import sys
-import urlparse
+import urllib.parse
 
 from thrift.transport import TSocket
 from thrift.transport import TTransport

--- a/thriftcli/thrift_zookeeper_resolver.py
+++ b/thriftcli/thrift_zookeeper_resolver.py
@@ -13,7 +13,7 @@
 import json
 import os
 import random
-import urlparse
+import urllib.parse
 
 from kazoo.client import KazooClient
 

--- a/thriftcli/transport.py
+++ b/thriftcli/transport.py
@@ -6,7 +6,7 @@ and auditing ofthese requests.
 TProxySocket is a thin wrapper around TSocket transport that uses httplib to handle setting up the tunnel 
 and requests_kerberos to handle kerberos auth.
 """
-import httplib
+import http.client
 import requests_kerberos
 import socket
 


### PR DESCRIPTION
This migrates thriftcli to Python3.