### PR TITLE
Bug-fix: non-proxied ssl client is rejecting connection on handshake due to certification validation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ And the main options:
 - **-j --json**            Print result in JSON format
 - **-t --tls**             Use TLS socket if provided
 - **-k --tls_key_path**    path to tls key file. Provides client identity to enable mTLS communication.  Has effect only if --tls key is provided
+- **-m --cert_verification_mode** Peer certificate validation mode.
+                            **none** : server's certificate will not be validated. Connection will be established even if certificate is absent
+                            **optional** : server's certificate will be validated if provided. Absence of certificate doesn't prevent the connection
+                            **required** : Valid certificate must be provided by the server. This is default value if omitted
 - **-i --client_id [client_id]**
                             Finagle client id to send request with
 - **-v --verbose**         Provide detailed logging

--- a/thriftcli/thrift_executor.py
+++ b/thriftcli/thrift_executor.py
@@ -148,8 +148,9 @@ class ThriftExecutor(object):
                 if self._tls_key_path is not None:
                     ssl_context.load_cert_chain(self._tls_key_path, self._tls_key_path)
                 ssl_context.verify_mode = verifier_type
-                self._transport = TSSLSocket.TSSLSocket(url, port, ssl_context=ssl_context)
-        else:
+                self._transport = TSSLSocket.TSSLSocket(url, port, ca_certs=self._tls_key_path,
+                                                        validate_callback=lambda cert, hostname: None)  # disabling hostname validation
+    else:
             if self._proxy:
                 proxy_host, proxy_port = self._proxy.split(":")
                 self._transport = TProxySocket(proxy_host, proxy_port, url, port)


### PR DESCRIPTION
Non-proxied ssl client now gets proper ca configuration to accept incoming handshakes in cases of cert_verification_mode!=none